### PR TITLE
Use File.realpath

### DIFF
--- a/core/kernel/require_relative_spec.rb
+++ b/core/kernel/require_relative_spec.rb
@@ -8,9 +8,9 @@ ruby_version_is "1.9" do
     before :each do
       CodeLoadingSpecs.spec_setup
       @dir = "../../fixtures/code"
-      @abs_dir = File.expand_path(@dir, File.dirname(__FILE__))
+      @abs_dir = File.realpath(@dir, File.dirname(__FILE__))
       @path = "#{@dir}/load_fixture.rb"
-      @abs_path = File.expand_path(@path, File.dirname(__FILE__))
+      @abs_path = File.realpath(@path, File.dirname(__FILE__))
     end
 
     after :each do

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -48,7 +48,10 @@ unless ENV['MSPEC_RUNNER']
   end
 end
 
-CODE_LOADING_DIR = File.expand_path "../fixtures/code", __FILE__
+dir = "../fixtures/code"
+CODE_LOADING_DIR = defined?(:require_relative) ?
+                     File.realpath(dir, __FILE__) :
+                     File.expand_path(dir, __FILE__)
 
 minimum_version = "1.5.17"
 unless MSpec::VERSION >= minimum_version


### PR DESCRIPTION
Real paths are used since `require_relative` is introduced.

Fixes failures when the build directory is a symlink.