### PR TITLE
Specify Comparable#<=> for ruby trunk

### DIFF
--- a/core/comparable/equal_value_spec.rb
+++ b/core/comparable/equal_value_spec.rb
@@ -34,65 +34,112 @@ describe "Comparable#==" do
     (a == b).should == false
   end
 
-  ruby_version_is ""..."1.9" do
-    it "returns nil if calling #<=> on self returns nil or a non-Integer" do
-      a = ComparableSpecs::Weird.new(0)
-      b = ComparableSpecs::Weird.new(10)
+  context "when #<=> returns nil" do
+    ruby_version_is ""..."1.9" do
+      it "returns nil" do
+        a = ComparableSpecs::Weird.new(0)
+        b = ComparableSpecs::Weird.new(10)
 
-      a.should_receive(:<=>).once.and_return(nil)
-      (a == b).should == nil
+        a.should_receive(:<=>).once.and_return(nil)
+        (a == b).should == nil
+      end
+    end
 
-      a = ComparableSpecs::Weird.new(0)
-      a.should_receive(:<=>).once.and_return("abc")
-      (a == b).should == nil
+    ruby_version_is "1.9" do
+      it "returns false" do
+        a = ComparableSpecs::Weird.new(0)
+        b = ComparableSpecs::Weird.new(10)
+
+        a.should_receive(:<=>).once.and_return(nil)
+        (a == b).should be_false
+      end
     end
   end
 
-  ruby_version_is "1.9" do
-    it "returns false if calling #<=> on self returns nil or a non-Integer" do
-      a = ComparableSpecs::Weird.new(0)
-      b = ComparableSpecs::Weird.new(10)
+  context "when #<=> returns nor nil neither an Integer" do
+    ruby_version_is ""..."1.9" do
+      it "returns nil" do
+        a = ComparableSpecs::Weird.new(0)
+        b = ComparableSpecs::Weird.new(10)
 
-      a.should_receive(:<=>).once.and_return(nil)
-      (a == b).should be_false
+        a.should_receive(:<=>).once.and_return("abc")
+        (a == b).should == nil
+      end
+    end
 
-      a = ComparableSpecs::Weird.new(0)
-      a.should_receive(:<=>).once.and_return("abc")
-      (a == b).should be_false
+    ruby_version_is "1.9"..."2.3" do
+      it "returns false" do
+        a = ComparableSpecs::Weird.new(0)
+        b = ComparableSpecs::Weird.new(10)
+
+        a.should_receive(:<=>).once.and_return("abc")
+        (a == b).should be_false
+      end
+    end
+
+    ruby_version_is "2.3" do
+      it "raises an ArgumentError" do
+        a = ComparableSpecs::Weird.new(0)
+        b = ComparableSpecs::Weird.new(10)
+
+        a.should_receive(:<=>).once.and_return("abc")
+        lambda { a == b }.should raise_error(ArgumentError)
+      end
     end
   end
 
-  ruby_version_is ""..."1.9" do
-    it "returns nil if calling #<=> on self raises a StandardError" do
+  context "when #<=> raises an exception" do
+    it "lets it go through if it is not a StandardError" do
       a = ComparableSpecs::Weird.new(0)
       b = ComparableSpecs::Weird.new(10)
-
-      def a.<=>(b) raise StandardError, "test"; end
-      (a == b).should == nil
-
-      # TypeError < StandardError
-      def a.<=>(b) raise TypeError, "test"; end
-      (a == b).should == nil
 
       def a.<=>(b) raise Exception, "test"; end
-      lambda { (a == b).should == nil }.should raise_error(Exception)
+      lambda { a == b }.should raise_error(Exception)
     end
-  end
 
-  ruby_version_is "1.9" do
-    # Behaviour confirmed by MRI test suite
-    it "returns false if calling #<=> on self raises an Exception" do
-      a = ComparableSpecs::Weird.new(0)
-      b = ComparableSpecs::Weird.new(10)
+    ruby_version_is ""..."1.9" do
+      it "returns nil if it is a StandardError" do
+        a = ComparableSpecs::Weird.new(0)
+        b = ComparableSpecs::Weird.new(10)
 
-      def a.<=>(b) raise StandardError, "test"; end
-      (a == b).should be_false
+        def a.<=>(b) raise StandardError, "test"; end
+        (a == b).should == nil
 
-      def a.<=>(b) raise TypeError, "test"; end
-      (a == b).should be_false
+        # TypeError < StandardError
+        def a.<=>(b) raise TypeError, "test"; end
+        (a == b).should == nil
+      end
+    end
 
-      def a.<=>(b) raise Exception, "test"; end
-      lambda { (a == b).should be_false }.should raise_error(Exception)
+    ruby_version_is "1.9"..."2.3" do
+      # Behaviour confirmed by MRI test suite
+      it "returns false if it is a StandardError" do
+        a = ComparableSpecs::Weird.new(0)
+        b = ComparableSpecs::Weird.new(10)
+
+        def a.<=>(b) raise StandardError, "test"; end
+        (a == b).should be_false
+
+        def a.<=>(b) raise TypeError, "test"; end
+        (a == b).should be_false
+      end
+    end
+
+    ruby_version_is "2.3" do
+      # Behaviour confirmed by MRI test suite
+      it "lets it go through if it is a StandardError" do
+        a = ComparableSpecs::Weird.new(0)
+        b = ComparableSpecs::Weird.new(10)
+
+        def a.<=>(b) raise StandardError, "test"; end
+        lambda { (a == b).should be_false }.should raise_error(StandardError)
+
+        def a.<=>(b) raise TypeError, "test"; end
+        lambda { (a == b).should be_false }.should raise_error(TypeError)
+
+        def a.<=>(b) raise Exception, "test"; end
+        lambda { (a == b).should be_false }.should raise_error(Exception)
+      end
     end
   end
 end

--- a/core/comparable/equal_value_spec.rb
+++ b/core/comparable/equal_value_spec.rb
@@ -14,11 +14,11 @@ describe "Comparable#==" do
     a = ComparableSpecs::Weird.new(0)
     b = ComparableSpecs::Weird.new(10)
 
-    a.should_receive(:<=>).any_number_of_times.and_return(0)
+    a.should_receive(:<=>).once.and_return(0)
     (a == b).should == true
 
     a = ComparableSpecs::Weird.new(0)
-    a.should_receive(:<=>).any_number_of_times.and_return(0.0)
+    a.should_receive(:<=>).once.and_return(0.0)
     (a == b).should == true
   end
 
@@ -26,11 +26,11 @@ describe "Comparable#==" do
     a = ComparableSpecs::Weird.new(0)
     b = ComparableSpecs::Weird.new(10)
 
-    a.should_receive(:<=>).any_number_of_times.and_return(1)
+    a.should_receive(:<=>).once.and_return(1)
     (a == b).should == false
 
     a = ComparableSpecs::Weird.new(0)
-    a.should_receive(:<=>).any_number_of_times.and_return(-1)
+    a.should_receive(:<=>).once.and_return(-1)
     (a == b).should == false
   end
 
@@ -39,11 +39,11 @@ describe "Comparable#==" do
       a = ComparableSpecs::Weird.new(0)
       b = ComparableSpecs::Weird.new(10)
 
-      a.should_receive(:<=>).any_number_of_times.and_return(nil)
+      a.should_receive(:<=>).once.and_return(nil)
       (a == b).should == nil
 
       a = ComparableSpecs::Weird.new(0)
-      a.should_receive(:<=>).any_number_of_times.and_return("abc")
+      a.should_receive(:<=>).once.and_return("abc")
       (a == b).should == nil
     end
   end
@@ -53,11 +53,11 @@ describe "Comparable#==" do
       a = ComparableSpecs::Weird.new(0)
       b = ComparableSpecs::Weird.new(10)
 
-      a.should_receive(:<=>).any_number_of_times.and_return(nil)
+      a.should_receive(:<=>).once.and_return(nil)
       (a == b).should be_false
 
       a = ComparableSpecs::Weird.new(0)
-      a.should_receive(:<=>).any_number_of_times.and_return("abc")
+      a.should_receive(:<=>).once.and_return("abc")
       (a == b).should be_false
     end
   end


### PR DESCRIPTION
Hello,
I plan to change the behavior of Comparable#<=> according to https://bugs.ruby-lang.org/issues/7688.
Should I update RubySpec before to avoid CI failure?