### PR TITLE
no silent rescue

### DIFF
--- a/core/comparable/equal_value_spec.rb
+++ b/core/comparable/equal_value_spec.rb
@@ -2,61 +2,56 @@ require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 
 describe "Comparable#==" do
-  it "returns true if other is the same as self" do
+  a = b = nil
+  before :each do
     a = ComparableSpecs::Weird.new(0)
-    b = ComparableSpecs::Weird.new(20)
+    b = ComparableSpecs::Weird.new(10)
+  end
 
+  it "returns true if other is the same as self" do
     (a == a).should == true
     (b == b).should == true
   end
 
   it "calls #<=> on self with other and returns true if #<=> returns 0" do
-    a = ComparableSpecs::Weird.new(0)
-    b = ComparableSpecs::Weird.new(10)
-
     a.should_receive(:<=>).any_number_of_times.and_return(0)
     (a == b).should == true
+  end
 
-    a = ComparableSpecs::Weird.new(0)
+  it "calls #<=> on self with other and returns true if #<=> returns 0.0" do
     a.should_receive(:<=>).any_number_of_times.and_return(0.0)
     (a == b).should == true
   end
 
-  it "returns false if calling #<=> on self returns a non-zero Integer" do
-    a = ComparableSpecs::Weird.new(0)
-    b = ComparableSpecs::Weird.new(10)
-
+  it "returns false if calling #<=> on self returns a positive Integer" do
     a.should_receive(:<=>).any_number_of_times.and_return(1)
     (a == b).should == false
+  end
 
-    a = ComparableSpecs::Weird.new(0)
+  it "returns false if calling #<=> on self returns a negative Integer" do
     a.should_receive(:<=>).any_number_of_times.and_return(-1)
     (a == b).should == false
   end
 
   ruby_version_is ""..."1.9" do
-    it "returns nil if calling #<=> on self returns nil or a non-Integer" do
-      a = ComparableSpecs::Weird.new(0)
-      b = ComparableSpecs::Weird.new(10)
-
+    it "returns nil if calling #<=> on self returns nil" do
       a.should_receive(:<=>).any_number_of_times.and_return(nil)
       (a == b).should == nil
+    end
 
-      a = ComparableSpecs::Weird.new(0)
+    it "returns nil if calling #<=> on self returns a non-Integer" do
       a.should_receive(:<=>).any_number_of_times.and_return("abc")
       (a == b).should == nil
     end
   end
 
   ruby_version_is "1.9" do
-    it "returns false if calling #<=> on self returns nil or a non-Integer" do
-      a = ComparableSpecs::Weird.new(0)
-      b = ComparableSpecs::Weird.new(10)
-
+    it "returns false if calling #<=> on self returns nil" do
       a.should_receive(:<=>).any_number_of_times.and_return(nil)
       (a == b).should be_false
+    end
 
-      a = ComparableSpecs::Weird.new(0)
+    it "returns false if calling #<=> on self returns a non-Integer" do
       a.should_receive(:<=>).any_number_of_times.and_return("abc")
       (a == b).should be_false
     end
@@ -64,35 +59,32 @@ describe "Comparable#==" do
 
   ruby_version_is ""..."1.9" do
     it "returns nil if calling #<=> on self raises a StandardError" do
-      a = ComparableSpecs::Weird.new(0)
-      b = ComparableSpecs::Weird.new(10)
-
       def a.<=>(b) raise StandardError, "test"; end
       (a == b).should == nil
+    end
 
+    it "returns nil if calling #<=> on self raises a subclass of StandardError" do
       # TypeError < StandardError
       def a.<=>(b) raise TypeError, "test"; end
       (a == b).should == nil
-
-      def a.<=>(b) raise Exception, "test"; end
-      lambda { (a == b).should == nil }.should raise_error(Exception)
     end
   end
 
   ruby_version_is "1.9" do
     # Behaviour confirmed by MRI test suite
-    it "returns false if calling #<=> on self raises an Exception" do
-      a = ComparableSpecs::Weird.new(0)
-      b = ComparableSpecs::Weird.new(10)
-
+    it "returns false if calling #<=> on self raises a StandardError" do
       def a.<=>(b) raise StandardError, "test"; end
       (a == b).should be_false
+    end
 
+    it "returns false if calling #<=> on self raises a subclass of StandardError" do
       def a.<=>(b) raise TypeError, "test"; end
       (a == b).should be_false
-
-      def a.<=>(b) raise Exception, "test"; end
-      lambda { (a == b).should be_false }.should raise_error(Exception)
     end
+  end
+
+  it "raises the exception if calling #<=> on self raises an unrescued exception" do
+    def a.<=>(b) raise Exception, "test"; end
+    lambda { (a == b) }.should raise_error(Exception)
   end
 end

--- a/core/comparable/equal_value_spec.rb
+++ b/core/comparable/equal_value_spec.rb
@@ -1,6 +1,8 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 
+no_silent_rescue = "2.3"
+
 describe "Comparable#==" do
   a = b = nil
   before :each do
@@ -50,10 +52,19 @@ describe "Comparable#==" do
       a.should_receive(:<=>).any_number_of_times.and_return(nil)
       (a == b).should be_false
     end
+  end
 
+  ruby_version_is "1.9"...no_silent_rescue do
     it "returns false if calling #<=> on self returns a non-Integer" do
       a.should_receive(:<=>).any_number_of_times.and_return("abc")
       (a == b).should be_false
+    end
+  end
+
+  ruby_version_is no_silent_rescue do
+    it "raise an ArgumentError if calling #<=> on self returns a non-Integer" do
+      a.should_receive(:<=>).any_number_of_times.and_return("abc")
+      lambda { (a == b) }.should raise_error(ArgumentError)
     end
   end
 
@@ -70,7 +81,7 @@ describe "Comparable#==" do
     end
   end
 
-  ruby_version_is "1.9" do
+  ruby_version_is "1.9"...no_silent_rescue do
     # Behaviour confirmed by MRI test suite
     it "returns false if calling #<=> on self raises a StandardError" do
       def a.<=>(b) raise StandardError, "test"; end
@@ -80,6 +91,18 @@ describe "Comparable#==" do
     it "returns false if calling #<=> on self raises a subclass of StandardError" do
       def a.<=>(b) raise TypeError, "test"; end
       (a == b).should be_false
+    end
+  end
+
+  ruby_version_is no_silent_rescue do
+    it "raises the exception if calling #<=> on self raises a StandardError" do
+      def a.<=>(b) raise StandardError, "test"; end
+      lambda { (a == b) }.should raise_error(StandardError)
+    end
+
+    it "raises the exception if calling #<=> on self raises a subclass of StandardError" do
+      def a.<=>(b) raise TypeError, "test"; end
+      lambda { (a == b) }.should raise_error(TypeError)
     end
   end
 


### PR DESCRIPTION
`Comparable#==` no longer silently rescues any Exception.
[ruby-core:51389] [Bug #7688]