### PR TITLE
Fix for r46355 and r49638

### DIFF
--- a/language/predefined_spec.rb
+++ b/language/predefined_spec.rb
@@ -769,7 +769,7 @@ describe "Processing RUBYOPT" do
     it "prints the version number for '-v'" do
       ENV["RBXOPT"] = '-X19'
       ENV["RUBYOPT"] = '-v'
-      ruby_exe("").chomp.should == RUBY_DESCRIPTION
+      ruby_exe("")[/\A.*/].should == RUBY_DESCRIPTION
     end
   end
 


### PR DESCRIPTION
Match only the first line, as extra lines (currently last_commit
and malloc_conf) may be shown.